### PR TITLE
Fixed Repeat Command's Error Message

### DIFF
--- a/src/main/java/com/wylxbot/wylx/Commands/ServerUtil/RepeatCommand.java
+++ b/src/main/java/com/wylxbot/wylx/Commands/ServerUtil/RepeatCommand.java
@@ -17,7 +17,7 @@ public class RepeatCommand extends ThreadedCommand {
         String[] args = ctx.args();
         int x;
         if(args.length < 3){
-            event.getMessage().reply("Usage $repeat <int x> <str msg>").queue();
+            event.getChannel().sendMessage(getDescription(ctx.prefix())).queue();
             return;
         }
         try{


### PR DESCRIPTION
Error message referenced command using '$' prefix. This change uses the standard getDescription(ctx.prefix()) that is used by other commands upon error in order to show the potentially changed prefix.